### PR TITLE
Fix OpenAI parameter name

### DIFF
--- a/gsc_direct.py
+++ b/gsc_direct.py
@@ -155,7 +155,11 @@ class GSCDirectMode:
                 model=self.OPENAI_MODEL,
                 messages=[{"role": "user", "content": full_prompt}],
                 temperature=0.3,
-                max_tokens=1024,
+                # Some providers expect the parameter name 'max_completion_tokens'
+                # instead of 'max_tokens'. Using the more compatible parameter
+                # avoids API errors like:
+                # "Unsupported parameter: 'max_tokens' is not supported with this model."
+                max_completion_tokens=1024,
             )
 
             answer = response["choices"][0]["message"]["content"].strip()
@@ -255,7 +259,9 @@ Restituisci SOLO il codice Python.
                 model=self.OPENAI_MODEL,
                 messages=[{"role": "user", "content": chart_prompt}],
                 temperature=0.2,
-                max_tokens=512,
+                # Use 'max_completion_tokens' for wider compatibility with
+                # models that do not accept the 'max_tokens' parameter.
+                max_completion_tokens=512,
             )
 
             code_content = response["choices"][0]["message"]["content"].strip()


### PR DESCRIPTION
## Summary
- use `max_completion_tokens` for compatibility with some LLM providers

## Testing
- `python -m py_compile gsc_direct.py bigquery_mode.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_687a563136bc832cadaf4300b0f50002