### PR TITLE
Improve BigQuery credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ User Question → AI → SQL → BigQuery → DataFrame → AI Summary → Respo
 - ✅ Verifica permessi IAM del progetto
 - ✅ Controlla nome progetto nei secrets
 
+**"ACCESS_TOKEN_SCOPE_INSUFFICIENT"**
+- ✅ Revoca l'autorizzazione dell'app dal tuo [Google Account](https://myaccount.google.com/permissions)
+- ✅ Esegui nuovamente il login per includere gli scope BigQuery
+
 **"OpenAI authentication failed"**
 - ✅ Verifica API key OpenAI
 - ✅ Controlla quota e limiti


### PR DESCRIPTION
## Summary
- keep scoped GCP credentials in session state
- pass credentials object when using `bigquery.Client`
- document how to recover from `ACCESS_TOKEN_SCOPE_INSUFFICIENT`

## Testing
- `python -m py_compile app.py gsc_direct.py bigquery_mode.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7d9f3120832ca58c126986c76719